### PR TITLE
Fall back to `nodeContentDigest` when `item` doesn't have an `id`

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -14,8 +14,10 @@ exports.sourceNodes = ( { actions, createNodeId, createContentDigest },
     });
 
     const processData = item => {
-      const nodeId = createNodeId(`dynamodb-${item.id}`)
       const nodeContentDigest = createContentDigest(item)
+      const nodeId = item.id
+        ? createNodeId(`dynamodb-${item.id}`)
+        : nodeContentDigest
       
       const nodeData = Object.assign({}, item, {
         id: nodeId,

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -46,8 +46,8 @@ exports.sourceNodes = ( { actions, createNodeId, createContentDigest },
     
         if (typeof data.LastEvaluatedKey != "undefined") {
           console.log("Scanning for more...");
-          params.ExclusiveStartKey = data.LastEvaluatedKey;
-          docClient.scan(params, onScan);
+          options.params.ExclusiveStartKey = data.LastEvaluatedKey;
+          docClient.scan(options.params, onScan);
         } else {
           resolve()
         }


### PR DESCRIPTION
https://github.com/wmlutz/gatsby-source-dynamodb/pull/2